### PR TITLE
Added food saturation multiplier

### DIFF
--- a/src/main/java/iguanaman/hungeroverhaul/config/IguanaConfig.java
+++ b/src/main/java/iguanaman/hungeroverhaul/config/IguanaConfig.java
@@ -336,7 +336,7 @@ public class IguanaConfig
         Property modFoodSaturationMultiplierProperty = config.get("food", "modFoodSaturationMultiplier", 1);
         modFoodSaturationMultiplierProperty.comment = "Other mod's food saturation values are multiplied by this ('modifyFoodValues' must be true). Recommended range between 0.8 and 1.2";
         modFoodSaturationMultiplier = modFoodSaturationMultiplierProperty.getDouble(1);
-        modFoodSaturationMultiplierProperty.set(modFoodValueDivider);
+        modFoodSaturationMultiplierProperty.set(modFoodSaturationMultiplier);
 
         Property addWellFedEffectProperty = config.get("food", "addWellFedEffect", true);
         addWellFedEffectProperty.comment = "Adds a 'well fed' effect that gives slight health regen";

--- a/src/main/java/iguanaman/hungeroverhaul/food/FoodModifier.java
+++ b/src/main/java/iguanaman/hungeroverhaul/food/FoodModifier.java
@@ -31,6 +31,9 @@ public class FoodModifier
             float saturationValue = Math.max(foodValue / 20F, 0F);
             event.foodValues = new FoodValues(foodValue, saturationValue);
         }
+        float newSaturationValue = event.foodValues.saturationModifier;
+        newSaturationValue = (float) (newSaturationValue * IguanaConfig.modFoodSaturationMultiplier);
+        event.foodValues = new FoodValues(event.foodValues.hunger, newSaturationValue);
     }
 
     public static void setModifiedFoodValues(Item item, FoodValues values)


### PR DESCRIPTION
I noticed that after HO applies its tweaks, the amount of saturation restored relative to hunger is lower than it is in vanilla. I added a float multiplier that defaults to 1.0 (unchanged), and it modifies just the saturation value of the food event. Getting a food saturation level similar to vanilla is somewhere between 1.2 and 1.4, depending on how you feel about feasts giving over 20 saturation (cooked beef gives 20.8 in vanilla).
