### PR TITLE
Fixed Rotten flesh not begin stacked enough to be traded with villagers

### DIFF
--- a/src/main/java/iguanaman/hungeroverhaul/module/tweak/TweaksModule.java
+++ b/src/main/java/iguanaman/hungeroverhaul/module/tweak/TweaksModule.java
@@ -56,6 +56,12 @@ public class TweaksModule
         {
             newStackSize = Config.foodStackSizeMultiplier;
         }
+        
+        //Rotten Flesh stack size fix for trading
+        if (item.getRegistryName().equals(new ResourceLocation("minecraft:rotten_flesh")))
+        {
+            newStackSize = Math.max(8 * Config.foodStackSizeMultiplier, 40);
+        }
 
         if (curStackSize > newStackSize)
         {


### PR DESCRIPTION
The stack size is decided between the maximum of 40 (the maximum of rotten flesh a villager accept) and the base stack size calculation 
Fixed #170